### PR TITLE
ABRMS-6528 Umgebungsvariable benutzen

### DIFF
--- a/workflows/ms-cicd/release.yml
+++ b/workflows/ms-cicd/release.yml
@@ -205,6 +205,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           JIRA_CLOUD_URL: ${{ env.JIRA_CLOUD_URL }}
           COVERAGE_OUTPUT: ${{ steps.fetch-coverage.outputs.coverage }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         shell: bash
         run: |
           template_file=".github/templates/release_template.md"
@@ -276,7 +277,7 @@ jobs:
           
             # Renovate Ticket überspringen, Rest aber prüfen
             if [ "$issueNumber" = "ABRMS-5265" ]; then
-              title="${{ github.event.pull_request.title }}"
+              title="$PR_TITLE"
               issueListLines+="| ABRMS-5265 | $title | Renovate | Renovate |"$'\n'
               echo "renovate=true" >> "$GITHUB_OUTPUT"
               echo "renovate_title=$title" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Ich bin mir nicht sicher, ob das wirklich das Problem war und das dann löst; in meinen Tests konnte ich den Fehler nicht nachstellen. Immerhin werden Anführungszeichen beim Verwenden der Umgebungsvariable mitgenommen.

Test-Versuche:
wegen übergebenem Ticket wird die Stelle angesprungen, die GitHub-Variable mit "" macht aber keine Probleme, die "" werden nur nicht angezeigt: https://github.com/freenet-group/ms-commondata/actions/runs/12392623208/job/34592184638

selbes Szenario, diesmal mit Verwendung der Umgebungsvariable, die "" werden angezeigt:
https://github.com/freenet-group/ms-commondata/actions/runs/12392761716/job/34592621301
