### PR TITLE
ABRMS-6526 sanityTestsEnabled auch bei release

### DIFF
--- a/workflows/ms-cicd/release.yml
+++ b/workflows/ms-cicd/release.yml
@@ -22,6 +22,11 @@ on:
         description: 'Ist dies ein Pre-Release?'
         required: false
         type: boolean
+      sanityTestsEnabled:
+        default: true
+        description: Flag zum Deaktivieren der SanityTests beim Deployment nach Releasebuild. Standardmäßig aktiviert.
+        required: false
+        type: boolean
 
 jobs:
   release:
@@ -495,7 +500,8 @@ jobs:
             {
               "environment": "dev",
               "component": "${{ env.COMPONENT }}", 
-              "componentVersion": "${{ steps.version-calculation.outputs.new_version }}"
+              "componentVersion": "${{ steps.version-calculation.outputs.new_version }}",
+              "sanityTestsEnabled": ${{ inputs.sanityTestsEnabled }}
             }
 
       - name: Deployment Workflow Status prüfen


### PR DESCRIPTION
Kleine Lösung, um CICD-Releases bauen zu können, wenn Sanity-Checks nicht gehen.
Siehe
https://github.com/freenet-group/ms-commondata/actions/runs/12394153558/job/34596942057
und
https://github.com/freenet-group/ms-commondata/actions/runs/12394314576