### PR TITLE
ABRMS-6475 Pet Deployment fixed und npm ci --force hinzugefügt

### DIFF
--- a/workflows/aws/deployment.yml
+++ b/workflows/aws/deployment.yml
@@ -99,7 +99,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Dependencies installieren
-        run: npm ci
+        run: npm ci --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_R_PACKAGES }}
 
@@ -114,8 +114,8 @@ jobs:
         if: steps.determine-environment.outputs.ENVIRONMENT == 'GIT'
         run: npm run deploy --stage=git
 
-      - name: Deployment auf PET, wenn PROD oder PET
-        if: steps.determine-environment.outputs.ENVIRONMENT == 'PET' || steps.determine-environment.outputs.ENVIRONMENT == 'PROD'
+      - name: Deployment auf PET, wenn GIT oder PET
+        if: steps.determine-environment.outputs.ENVIRONMENT == 'GIT' || steps.determine-environment.outputs.ENVIRONMENT == 'PET'
         run: npm run deploy --stage=pet
 
       - name: Deployment auf PROD

--- a/workflows/aws/pullRequestClosed.yml
+++ b/workflows/aws/pullRequestClosed.yml
@@ -31,7 +31,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Dependencies installieren
-        run: npm ci
+        run: npm ci --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_R_PACKAGES }}
 

--- a/workflows/aws/pullRequestTests.yml
+++ b/workflows/aws/pullRequestTests.yml
@@ -44,7 +44,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Dependencies installieren
-        run: npm ci
+        run: npm ci --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_R_PACKAGES }}
 
@@ -91,7 +91,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Dependencies installieren
-        run: npm ci
+        run: npm ci --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_R_PACKAGES }}
 

--- a/workflows/aws/release.yml
+++ b/workflows/aws/release.yml
@@ -72,7 +72,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Dependencies installieren
-        run: npm ci
+        run: npm ci --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_R_PACKAGES }}
 

--- a/workflows/aws/scheduledCleanup.yml
+++ b/workflows/aws/scheduledCleanup.yml
@@ -40,7 +40,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Dependencies installieren
-        run: npm ci
+        run: npm ci --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_R_PACKAGES }}
 

--- a/workflows/npm-lib/deployment.yml
+++ b/workflows/npm-lib/deployment.yml
@@ -62,7 +62,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Dependencies installieren
-        run: npm ci
+        run: npm ci --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_R_PACKAGES }}
 

--- a/workflows/npm-lib/pullRequestTests.yml
+++ b/workflows/npm-lib/pullRequestTests.yml
@@ -44,7 +44,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Dependencies installieren
-        run: npm ci
+        run: npm ci --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_R_PACKAGES }}
 
@@ -81,7 +81,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Dependencies installieren
-        run: npm ci
+        run: npm ci --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_R_PACKAGES }}
 

--- a/workflows/npm-lib/release.yml
+++ b/workflows/npm-lib/release.yml
@@ -72,7 +72,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
 
       - name: Dependencies installieren
-        run: npm ci
+        run: npm ci --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_R_PACKAGES }}
 


### PR DESCRIPTION
## Bugfixes
* `npm ci` auf `npm ci --force` umgestellt, da Legacy Komponenten z.B. bei cure benutzt werden und dort schon abgesichert sind.
* AWS Pet Deployment soll auch bei Git erfolgen. Config wird von Prod benutzt.