### PR TITLE
ABRMS-6475 Wenn vorhanden 'npn run remove' nutzen

### DIFF
--- a/workflows/aws/README.md
+++ b/workflows/aws/README.md
@@ -42,6 +42,14 @@ Die folgenden `npm run`-Skripte werden in diesem Projekt verwendet und müssen i
 - **`npm run format`**: Formatiert den Code gemäß den Regeln.
 - **`npm run test`**: Führt die Unit- und Integrationstests durch und erstellt eine Coverage unter coverage/coverage-summary.json.
 
+## Serverless
+
+Ein Deployment über Serverless findet über `npm run deploy --stage=<STAGE>` statt.
+Die Stage wird im WF durch die Nummer des PullRequest ergänzt. Eine mögliche Stage ist z.B. "pr-123".
+Damit diese Development Stages korrekt abgeräumt werden, wird über den WF `scheduledCleanup` mit `npm run remove --stage=<STAGE>` ein Cleanup nach 9 Tagen durchgeführt.
+
+❗ Der Service-Name in der Main-ServerlessConfig, darf kein "-" enthalten, da dies zu Problemen beim Entfernen des Stacks führen kann. ❗
+
 ## Serverless Framework Plugins
 
 Dieses Projekt verwendet das Serverless Framework für die Verwaltung und Bereitstellung serverloser Anwendungen. Die folgenden Plugins sind in der `serverless.yml`-Datei erforderlich und sollten in der `package.json` unter den `devDependencies` aufgeführt sein:

--- a/workflows/aws/README.md
+++ b/workflows/aws/README.md
@@ -36,9 +36,10 @@ Die folgenden `npm run`-Skripte werden in diesem Projekt verwendet und müssen i
 - **`npm run lint`**: Führt Linting-Checks durch, um den Code auf Style-Verstöße und potenzielle Fehler zu prüfen.
 - **`npm run lint:fix`**: Führt Linting-Checks durch und versucht, die gefundenen Probleme automatisch zu beheben.
 - **`npm run prettier:check`**: Überprüft, ob der Code den Prettier-Formatierungsregeln entspricht. (@deprecated - bitte `npm run format:check` verwenden)
-- **`npm run prettier:write`**: Formatiert den Code gemäß den Prettier-Regeln. (@deprecated - bitte `npm run format:write` verwenden)
+- **`npm run prettier:write`**: Formatiert den Code gemäß den Prettier-Regeln. (@deprecated - bitte `npm run format` verwenden)
 - **`npm run format:check`**: Überprüft, ob der Code Regeln entspricht.
 - **`npm run format:write`**: Formatiert den Code gemäß den Regeln.
+- **`npm run format`**: Formatiert den Code gemäß den Regeln.
 - **`npm run test`**: Führt die Unit- und Integrationstests durch und erstellt eine Coverage unter coverage/coverage-summary.json.
 
 ## Serverless Framework Plugins

--- a/workflows/aws/README.md
+++ b/workflows/aws/README.md
@@ -31,11 +31,14 @@ Die folgenden `npm run`-Skripte werden in diesem Projekt verwendet und müssen i
 
 - **`npm run build`**: Baut das Projekt und generiert die notwendigen Artefakte.
 - **`npm run deploy --stage=<STAGE>`**: Führt das Deployment für eine spezifische Stage durch, z.B. `git`, `pet`, `prod`.
+- **`npm run remove --stage=<STAGE>`**: Entfernt das Deployment für eine spezifische Stage, z.B. `git`, `pet`, `prod`.
 - **`npm run generate:sbom`**: Generiert eine SBOM-Datei.
 - **`npm run lint`**: Führt Linting-Checks durch, um den Code auf Style-Verstöße und potenzielle Fehler zu prüfen.
 - **`npm run lint:fix`**: Führt Linting-Checks durch und versucht, die gefundenen Probleme automatisch zu beheben.
-- **`npm run prettier:check`**: Überprüft, ob der Code den Prettier-Formatierungsregeln entspricht.
-- **`npm run prettier:write`**: Formatiert den Code gemäß den Prettier-Regeln.
+- **`npm run prettier:check`**: Überprüft, ob der Code den Prettier-Formatierungsregeln entspricht. (@deprecated - bitte `npm run format:check` verwenden)
+- **`npm run prettier:write`**: Formatiert den Code gemäß den Prettier-Regeln. (@deprecated - bitte `npm run format:write` verwenden)
+- **`npm run format:check`**: Überprüft, ob der Code Regeln entspricht.
+- **`npm run format:write`**: Formatiert den Code gemäß den Regeln.
 - **`npm run test`**: Führt die Unit- und Integrationstests durch und erstellt eine Coverage unter coverage/coverage-summary.json.
 
 ## Serverless Framework Plugins

--- a/workflows/aws/pullRequestClosed.yml
+++ b/workflows/aws/pullRequestClosed.yml
@@ -46,16 +46,25 @@ jobs:
         id: set-stage
         run: |
           if [ -n "${{ inputs.stage }}" ]; then
-            echo "STAGE=${{ inputs.stage }}" >> $GITHUB_ENV
+            echo "STAGE=${{ inputs.stage }}" >> $GITHUB_OUTPUT
           else
-            PR_NUMBER=$(echo ${{ github.event.pull_request.number }})
-            echo "STAGE=pr-${PR_NUMBER}" >> $GITHUB_ENV
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            echo "STAGE=pr${PR_NUMBER}" >> $GITHUB_OUTPUT
           fi
 
       - name: Serverless Deployment entfernen, wenn nicht GIT, PET oder PROD
+        env: 
+          STAGE: ${{ steps.set-stage.outputs.STAGE }}
         run: |
-          if [ "${{ env.STAGE }}" == "git" ] || [ "${{ env.STAGE }}" == "pet" ] || [ "${{ env.STAGE }}" == "prod" ]; then
+          echo "Überprüfe Stage: $STAGE"
+          if echo "$STAGE" | grep -iqE '^(git|pet|prod)$'; then
             echo "Stage darf nicht entfernt werden"
             exit 1
           fi
-          npx sls remove --stage ${{ env.STAGE }} --verbose
+          
+          # Nutze 'npm run remove' wenn vorhanden, ansonsten fallback auf 'npx serverless remove', 
+          if [ -f "package.json" ] && grep -q '"remove":' package.json; then
+            npm run remove --stage "$STAGE"
+          else
+            npx serverless remove --stage "$STAGE"
+          fi

--- a/workflows/aws/pullRequestTests.yml
+++ b/workflows/aws/pullRequestTests.yml
@@ -106,7 +106,7 @@ jobs:
 
       # Tests starten
       - name: Tests ausführen und Coverage generieren
-        run: npm run test --stage=pr-${{ github.event.number }}
+        run: npm run test --stage=pr${{ github.event.number }}
 
       # Coverage als Comment posten
       - name: Coverage Report als PR-Kommentar posten

--- a/workflows/aws/scheduledCleanup.yml
+++ b/workflows/aws/scheduledCleanup.yml
@@ -132,6 +132,10 @@ jobs:
               continue
             fi
 
-            # sls remove mit den entsprechenden Optionen ausführen
-            npx serverless remove --stage "$STAGE_NAME"
+            # Nutze 'npm run remove' wenn vorhanden, ansonsten fallback auf 'npx serverless remove', 
+            if [ -f "package.json" ] && grep -q '"remove":' package.json; then
+              npm run remove --stage "$STAGE_NAME"
+            else
+              npx serverless remove --stage "$STAGE_NAME"
+            fi
           done

--- a/workflows/aws/scheduledCleanup.yml
+++ b/workflows/aws/scheduledCleanup.yml
@@ -80,9 +80,9 @@ jobs:
           echo "Stacks output:"
           cat stacks.json
 
-          # Stack-Namen extrahieren und nach Service-Name filtern
+          # Stack-Namen extrahieren, nach Service-Name filtern und SubStacks mit mehreren "-" ignorieren
           OLD_STACKS=$(jq -r --arg date "$THRESHOLD_DATE" --arg service "$SERVICE_NAME" \
-            '.Stacks[] | select(.CreationTime < $date and (.StackName | startswith($service + "-"))) | .StackName' stacks.json)
+            '.Stacks[] | select(.CreationTime < $date and (.StackName | startswith($service + "-")) and (.StackName | gsub($service + "-"; "") | test("^[^\\-]+$"))) | .StackName' stacks.json)
 
           # Debugging: Check filtered stacks
           echo "Filtered stacks based on service name and date: $OLD_STACKS"


### PR DESCRIPTION
## Feature
* Sofern `npm run remove` vorhanden ist, soll dieser Befehl statt `npx sls remove` genutzt werden. Dadurch können auch Deployments entfernt werden, welche aus mehr als einem Stack bestehen
* Damit Stacks wie "cure-frontend-bpahl" nicht einzelnd abgeräumt werden, werden jetzt alle Stages mit mehr als 1 "-" ignoriert. Damit die PR Stacks funktionieren wurden diese nun von "cure-pr-111" auf "cure-pr111" umbenannt.